### PR TITLE
feat: add sticky header to blog pages

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -53,7 +53,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
   return (
     <div className="min-h-screen flex flex-col">
       {/* Header */}
-      <header className="border-b">
+      <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-sm">
         <div className="container flex h-16 items-center justify-between">
           <MainNav />
         </div>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -21,7 +21,7 @@ export default function BlogPage() {
   return (
     <div className="min-h-screen flex flex-col">
       {/* Header */}
-      <header className="border-b">
+      <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-sm">
         <div className="container flex h-16 items-center justify-between">
           <MainNav />
         </div>


### PR DESCRIPTION
- Implement sticky navigation header on blog index and individual post pages
- Add semi-transparent background with backdrop blur for better readability
- Use high z-index to ensure header stays above content when scrolling
- Improve user experience by keeping navigation always accessible

🤖 Generated with [Claude Code](https://claude.ai/code)